### PR TITLE
It looks to me as if minimatch is not needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "minimatch": "^10.0.1"
+        "@babel/runtime": "^7.26.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.25.9",
@@ -17833,30 +17832,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/minimist": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "bump-major": "npm version major --no-git-tag-version"
   },
   "dependencies": {
-    "@babel/runtime": "^7.26.0",
-    "minimatch": "^10.0.1"
+    "@babel/runtime": "^7.26.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.25.9",


### PR DESCRIPTION
I was running into issues when using `minimatch` in my gatsby setup:

```
ModuleBuildError: Module build failed (from ./node_modules/gatsby/dist/utils/babel-loader.j
  s):
  SyntaxError: /workspace/node_modules/@dnwjn/gatsby-plugin-plausible/node_modules/minimatch/
  dist/commonjs/ast.js: Class private methods are not enabled. Please add `@babel/plugin-tran
  sform-private-methods` to your configuration.
```

Removing `minimatch` fixes this.

You can try installing my package:

```
npm i @jonaspiela/gatsby-plugin-plausible
```

I couldn't find anything that `minimatch` was needed for.

What do you think? Do you want to merge this so others can benefit as well?